### PR TITLE
Restore Cyclic player launcher recipe

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -15,6 +15,7 @@ Bug Fixes:
 * Fixed Betweenland items being repairable in the Cyclic Anvil. As it's not intended from the mod.
 * Fixed Bronze Tool recipe issue and added Copper Tool recipes (#2802)
 * Fixed "Broken" tooltip from displaying on the Cyclic swords
+* Fixed Cyclic player launcher recipe
 
 Enhancements:
 * Add Ferdiand's Flowers glass blocks to sealable block list for Galacticraft (#2797)

--- a/src/scripts/staging/item_and_recipes/03_three/recipes.add.shaped.zs
+++ b/src/scripts/staging/item_and_recipes/03_three/recipes.add.shaped.zs
@@ -1316,6 +1316,13 @@ var shapedRecipes as IIngredient[][][][IItemStack] = {
 			[metals.iron.ingot, metals.iron.ingot, <minecraft:nether_wart>]
 		]
 	],
+	<cyclicmagic:tool_launcher> : [
+		[
+			[<minecraft:glowstone_dust>, <ore:slimeball>, <minecraft:quartz>],
+			[null, <minecraft:glowstone_dust>, <ore:slimeball>],
+			[<ore:string>, null, <minecraft:glowstone_dust>]
+		]
+	],
 
 	//Blood Magic
 	<bloodmagic:ritual_diviner> : [

--- a/src/scripts/staging/item_and_recipes/03_three/recipes.remove.zs
+++ b/src/scripts/staging/item_and_recipes/03_three/recipes.remove.zs
@@ -11,6 +11,7 @@ var removeItems as IItemStack[] = [
 	<cyclicmagic:charm_wing>,
 	<cyclicmagic:placer_block>,
 	<cyclicmagic:tool_auto_torch>,
+	<cyclicmagic:tool_launcher>,
 	<minecraft:cake>,
 	<oeintegration:excavatemodifier>,
 	<prospectors:prospector_med>,


### PR DESCRIPTION
Cyclic updated the player launcher recipe to now require a diamond, which doesn't fit age 3. This reverts it back to the old recipe.