### PR TITLE
fix(natura): Fix Bloodwood and Ghostwood making each others planks

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -26,6 +26,7 @@ Bug Fixes:
 * Fixed Bronze Tool recipe issue and added Copper Tool recipes (#2802)
 * Fixed "Broken" tooltip from displaying on the Cyclic swords
 * Fixed Cyclic player launcher recipe
+* Fixed Bloodwood and Ghostwood planks crafting each others slabs (#3173)
 * Fixed Steve's Carts Liquid Sensor recipe to fit age 3 (#3152)
 * Disabled "pistons move t es" from Quark to prevent crash with Cyclic Redstone Clock (#3110)
 * Disabled "What is 11?" Easter Egg with Actually Additions (#3140)

--- a/src/scripts/crafttweaker/recipes/mods/natura.zs
+++ b/src/scripts/crafttweaker/recipes/mods/natura.zs
@@ -25,9 +25,14 @@ import scripts.crafttweaker.stages.stageFive;
     Shaped Recipes
 */
 static shapedRecipes as IIngredient[][][][IItemStack] = {
-	<natura:nether_slab:1> * 3 : [
+	<natura:nether_slab:0> * 3 : [
 		[
 			[<natura:nether_planks:0>, <natura:nether_planks:0>, <natura:nether_planks:0>]
+		]
+	],
+	<natura:nether_slab:1> * 3 : [
+		[
+			[<natura:nether_planks:1>, <natura:nether_planks:1>, <natura:nether_planks:1>]
 		]
 	],
 	<natura:nether_slab:2> * 3 : [
@@ -40,9 +45,9 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[<natura:nether_planks:3>, <natura:nether_planks:3>, <natura:nether_planks:3>]
 		]
 	],
-	<natura:nether_slab:0> * 3 : [
+	<natura:overworld_slab2:0> * 3 : [
 		[
-			[<natura:nether_planks:1>, <natura:nether_planks:1>, <natura:nether_planks:1>]
+			[<natura:overworld_planks:5>, <natura:overworld_planks:5>, <natura:overworld_planks:5>]
 		]
 	],
 	<natura:overworld_slab2:1> * 3 : [
@@ -60,9 +65,9 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[<natura:overworld_planks:8>, <natura:overworld_planks:8>, <natura:overworld_planks:8>]
 		]
 	],
-	<natura:overworld_slab2:0> * 3 : [
+	<natura:overworld_slab:0> * 3 : [
 		[
-			[<natura:overworld_planks:5>, <natura:overworld_planks:5>, <natura:overworld_planks:5>]
+			[<natura:overworld_planks:0>, <natura:overworld_planks:0>, <natura:overworld_planks:0>]
 		]
 	],
 	<natura:overworld_slab:1> * 3 : [
@@ -83,11 +88,6 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	<natura:overworld_slab:4> * 3 : [
 		[
 			[<natura:overworld_planks:4>, <natura:overworld_planks:4>, <natura:overworld_planks:4>]
-		]
-	],
-	<natura:overworld_slab:0> * 3 : [
-		[
-			[<natura:overworld_planks:0>, <natura:overworld_planks:0>, <natura:overworld_planks:0>]
 		]
 	],
 	<natura:overworld_bookshelves:0> : [


### PR DESCRIPTION
Swap metadata in Bloodwood and Ghostwood plank recipes so they stop crafting each other.

Fixes #3173