### PR TITLE
refactor(extraplanets): Remove compressed zinc

### DIFF
--- a/src/scripts/crafttweaker/integrations/mods/galacticcraftAndExtraplanets.zs
+++ b/src/scripts/crafttweaker/integrations/mods/galacticcraftAndExtraplanets.zs
@@ -15,6 +15,9 @@
 	https://github.com/MJRLegends/GalacticraftTweaker/wiki/CraftTweakerSupport
 */
 function init() {
+	// Remove compressed zinc recipe.
+	mods.GalacticraftTweaker.removeCompressorRecipe(<extraplanets:tier8_items:4>);
+
 	// Remove all compressed steel plate recipes.
 	mods.GalacticraftTweaker.removeCompressorRecipe(<galacticraftcore:basic_item:9>);
 	// Add the correct steel recipe back.

--- a/src/scripts/crafttweaker/integrations/mods/modularMachinery/hydraulicPress.zs
+++ b/src/scripts/crafttweaker/integrations/mods/modularMachinery/hydraulicPress.zs
@@ -37,7 +37,6 @@ static recipes as IItemStack[][IItemStack] = {
 	<extraplanets:tier5_items:6>: [	metals.nickel.ingot.firstItem * 2 ], // Compressed Nickel
 	<extraplanets:tier6_items:4>: [ <extraplanets:tier6_items:5> * 2 ], // Compressed Magnesium
 	<extraplanets:tier7_items:4>: [ <extraplanets:tier7_items:5> * 2 ], // Compressed Crystal
-	<extraplanets:tier8_items:4>: [ <extraplanets:tier8_items:5> * 2 ], // Compressed Zinc
 	<extraplanets:tier9_items:4>: [ <extraplanets:tier9_items:5> * 2 ], // Compressed Tungsten
 	<extraplanets:tier10_items:4>: [ <extraplanets:tier10_items:5> * 2 ], // Compressed Dark Iron
 	<extraplanets:tier11_items:6>: [ <extraplanets:tier11_items:5> * 6 ], // Compressed Space Platinum

--- a/src/scripts/crafttweaker/staging/itemsAndRecipes/mods/extraplanets.zs
+++ b/src/scripts/crafttweaker/staging/itemsAndRecipes/mods/extraplanets.zs
@@ -630,7 +630,6 @@ static stagedItems as IIngredient[][string] = {
 		<extraplanets:tier8_items:1>,
 		<extraplanets:tier8_items:2>,
 		<extraplanets:tier8_items:3>,
-		<extraplanets:tier8_items:4>,
 		<extraplanets:tier8_items:5>,
 		<extraplanets:tier8_items:6>,
 		<extraplanets:tier8_items:0>,
@@ -745,7 +744,8 @@ static stagedItems as IIngredient[][string] = {
 static hiddenRemove as IIngredient[] = [
 	<extraplanets:advanced_refinery:0>,
 	<extraplanets:block_multi:0>,
-	<extraplanets:ultimate_refinery:0>
+	<extraplanets:ultimate_refinery:0>,
+	<extraplanets:tier8_items:4>
 ];
 
 function init() {

--- a/src/scripts/crafttweaker/staging/itemsAndRecipes/mods/galacticraft.zs
+++ b/src/scripts/crafttweaker/staging/itemsAndRecipes/mods/galacticraft.zs
@@ -383,7 +383,7 @@ static stagedItems as IIngredient[][string] = {
 
 static hiddenItems as IIngredient[] = [
 	<galacticraftcore:bucket_fuel:0>,
-	<galacticraftcore:refinery:0>
+	<galacticraftcore:refinery:0>,
 ];
 
 function init() {


### PR DESCRIPTION
Remove recipes and JEI presence of compressed zinc from Extra Planets due to it having no purpose or function.

fixes #3168