### PR TITLE
fix(extendedcrafting): Disable Iridium Singularity

### DIFF
--- a/src/config/extendedcrafting.cfg
+++ b/src/config/extendedcrafting.cfg
@@ -171,7 +171,7 @@ singularity {
         uranium=true
         chrome=false
         platinum=true
-        iridium=true
+        iridium=false
         signalum=false
         lumium=false
         enderium=false


### PR DESCRIPTION
Disable Iridium Singularity in Extended Crafting config due to not having iridium in the pack.

Fixes #2985