### PR TITLE
fix(betterwithmods): Nerf nether coal to make 1 instead of 4

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -49,6 +49,7 @@ Enhancements:
 * Made ore advancement descriptions uniform and corrected Y values.
 * Added trade with the FFBH mod to get Corn Seeds.
 * Fixed inconsistent recipes with Rice and some Bread recipes.
+* Nerfed Better With Mod's nether coal recipe to make 1 instead of 4.
 
 Forge:
 

--- a/src/scripts/crafttweaker/integrations/mods/betterwithmods.zs
+++ b/src/scripts/crafttweaker/integrations/mods/betterwithmods.zs
@@ -51,6 +51,7 @@ static soakingRemovals as IItemStack[] = [
 	Note: Removing by output also requires the amount of the output item that is given.
 */
 static cauldronRemovals as IItemStack[][] = [
+	[<betterwithmods:material:1> * 4],
 	[<betterwithmods:material:12>],
 	[<betterwithmods:material:12> * 2],
 	[<betterwithmods:material:12> * 3],
@@ -238,6 +239,7 @@ function init() {
 	Condensed.setContainer(<betterwithaddons:bolt:0>, <betterwithaddons:spindle:0>);
 
 	// Cauldron
+	betterWithMods.addCauldron([<ore:dustCarbon>, <betterwithmods:material:16>], [<betterwithmods:material:1>]);
 	betterWithMods.addCauldron([<minecraft:rotten_flesh:0>, <minecraft:rotten_flesh:0>, <minecraft:rotten_flesh:0>], [<betterwithmods:material:12>]);
 	betterWithMods.addCauldron([<primal:pigman_hide_raw:0>], [<betterwithmods:material:12> * 2]);
 	betterWithMods.addCauldron([<animalium:wild_dog_pelt:0>], [<betterwithmods:material:12>]);


### PR DESCRIPTION
Script Better With Mod's nether coal recipe to make 1 per craft instead of 4.