### PR TITLE
fix(contenttweaker): Add ores to oredicts to allow processing

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -54,6 +54,7 @@ should not be repairable anyways using this method. (#2925)
 * Added missing recipes for some power inputs for MM (#3090)
 * Fixed inconsistent recipe for VC frame upgrades (#2568)
 * Fixed raw pigman pelt processing recipe (#2912)
+* Fixed Content Tweaker ores only working in quartz grindstone (#3147)
 
 Enhancements:
 * Disabled more Cyclic Enhancements not needed for this pack.

--- a/src/scripts/crafttweaker/oredict/ores.zs
+++ b/src/scripts/crafttweaker/oredict/ores.zs
@@ -34,8 +34,6 @@
 <ore:oreGeolosysTeallite>.add(<geolosys:ore:5>);
 
 // Remove ore oredict on geolosys-styled CoT ores.
-<ore:oreGold>.remove(<materialpart:gold:ore_galacticraftplanets_bottom>);
-<ore:oreIron>.remove(<materialpart:iron:ore_galacticraftcore_bottom>);
 <ore:oreOsmium>.remove(<materialpart:osmium:ore_minecraft_stone>);
 
 // Remove Geolosys Zinc ore from oredict


### PR DESCRIPTION
Stoped removing the Content Tweaker ores from their oredicts so they can be processed by machines other than the quartz grindstone.

Fixes #3147