### PR TITLE
fix(BetterWithMods): Change wind chime recipe to fit age 1

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -31,6 +31,7 @@ Bug Fixes:
 * Fixed Cyclic player launcher recipe
 * Fixed Bloodwood and Ghostwood planks crafting each others slabs (#3173)
 * Fixed Steve's Carts Liquid Sensor recipe to fit age 3 (#3152)
+* Fixed Better With Mod's Bamboo Chimes recipe to be craftable in age 1, and made the Metal Chimes recipe match
 * Disabled "pistons move t es" from Quark to prevent crash with Cyclic Redstone Clock (#3110)
 * Disabled "What is 11?" Easter Egg with Actually Additions (#3140)
 * Disabled Coal Block to Diamonds in PneumaticCraft config to force it off.

--- a/src/scripts/crafttweaker/recipes/mods/betterwithmods.zs
+++ b/src/scripts/crafttweaker/recipes/mods/betterwithmods.zs
@@ -25,6 +25,90 @@ import scripts.crafttweaker.stages.stageFive;
     Shaped Recipes
 */
 static shapedRecipes as IIngredient[][][][IItemStack] = {
+	<betterwithmods:bamboo_chime:0> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_oak>, <ore:string>],
+			[<ore:sugarcane>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "oak"}, Name: "minecraft:planks"}}), <ore:sugarcane>]
+		]
+	],
+	<betterwithmods:bamboo_chime:1> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_spruce>, <ore:string>],
+			[<ore:sugarcane>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "spruce"}, Name: "minecraft:planks"}}), <ore:sugarcane>]
+		]
+	],
+	<betterwithmods:bamboo_chime:2> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_birch>, <ore:string>],
+			[<ore:sugarcane>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "birch"}, Name: "minecraft:planks"}}), <ore:sugarcane>]
+		]
+	],
+	<betterwithmods:bamboo_chime:3> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_jungle>, <ore:string>],
+			[<ore:sugarcane>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "jungle"}, Name: "minecraft:planks"}}), <ore:sugarcane>]
+		]
+	],
+	<betterwithmods:bamboo_chime:4> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_acacia>, <ore:string>],
+			[<ore:sugarcane>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "acacia"}, Name: "minecraft:planks"}}), <ore:sugarcane>]
+		]
+	],
+	<betterwithmods:bamboo_chime:5> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_bigoak>, <ore:string>],
+			[<ore:sugarcane>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "dark_oak"}, Name: "minecraft:planks"}}), <ore:sugarcane>]
+		]
+	],
+	<betterwithmods:metal_chime:0> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_oak>, <ore:string>],
+			[<minecraft:iron_ingot:0>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "oak"}, Name: "minecraft:planks"}}), <minecraft:iron_ingot:0>]
+		]
+	],
+	<betterwithmods:metal_chime:1> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_spruce>, <ore:string>],
+			[<minecraft:iron_ingot:0>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "spruce"}, Name: "minecraft:planks"}}), <minecraft:iron_ingot:0>]
+		]
+	],
+	<betterwithmods:metal_chime:2> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_birch>, <ore:string>],
+			[<minecraft:iron_ingot:0>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "birch"}, Name: "minecraft:planks"}}), <minecraft:iron_ingot:0>]
+		]
+	],
+	<betterwithmods:metal_chime:3> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_jungle>, <ore:string>],
+			[<minecraft:iron_ingot:0>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "jungle"}, Name: "minecraft:planks"}}), <minecraft:iron_ingot:0>]
+		]
+	],
+	<betterwithmods:metal_chime:4> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_acacia>, <ore:string>],
+			[<minecraft:iron_ingot:0>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "acacia"}, Name: "minecraft:planks"}}), <minecraft:iron_ingot:0>]
+		]
+	],
+	<betterwithmods:metal_chime:5> : [
+		[
+			[null, <ore:string>, null],
+			[<ore:string>, <primal:thin_slab_bigoak>, <ore:string>],
+			[<minecraft:iron_ingot:0>, <betterwithmods:moulding_wood>.withTag({texture: {Properties: {variant: "dark_oak"}, Name: "minecraft:planks"}}), <minecraft:iron_ingot:0>]
+		]
+	],
 	<betterwithmods:material:0> : [
 		[
 			[<totemic:buffalo_items:1>, <totemic:cedar_plank:0>, <totemic:buffalo_items:1>],
@@ -266,7 +350,9 @@ static removeRecipes as IIngredient[] = [
 	<betterwithmods:single_machine:0>,
 	<betterwithmods:wicker:0>,
 	<betterwithmods:wooden_axle:0>,
-	<betterwithmods:wooden_gearbox:0>
+	<betterwithmods:wooden_gearbox:0>,
+	<betterwithmods:bamboo_chime:*>,
+	<betterwithmods:metal_chime:*>
 ];
 
 static removeRegex as string[] = [


### PR DESCRIPTION
Replace pressure plate with thin slab in bamboo and metal chime recipes so that bamboo chimes can be made in age 1 while metal chimes are still matching the same recipe.