### PR TITLE
Changes shoggoth block hardness to match current version

### DIFF
--- a/src/config/abyssalcraft.cfg
+++ b/src/config/abyssalcraft.cfg
@@ -225,7 +225,7 @@ item_blacklist {
 
 shoggoth {
     # The minimum Block Hardness required for a Block to not be destroyed by Shoggoth Acid (some blocks are unaffected regardless of their hardness)\n[range: 2.1 ~ 51.0, default: 3.0]
-    D:"Acid Resistance Hardness"=3.0
+    D:"Acid Resistance Hardness"=2.1
 
     # The frequency (in ticks) at which a Lesser Shoggoth can spit acid. Higher values increase the time between each spit attack, while lower values descrease the time (and 0 disables it).\n[range: 0 ~ 300, default: 100]
     I:"Acid Spit Frequency"=100


### PR DESCRIPTION
the minimum block hardness to resist Lesser Shoggoth acid spit was changed from 3 to 2.1 in AbyssalCraft 1.9.4.9 and this significantly helps with their griefing and some to their currently very high difficulty. Also recommend updating the pack to the latest Abyssalcraft version for the next SevTech release as there are several anti-griefing bug fixes (breaking bedrock, destroying tile entities etc).

relevant abyssalcraft commit: https://github.com/Shinoow/AbyssalCraft/commit/8eabf832ac0cfc4f8fa4901505029e573abc63f1