### PR TITLE
Fix Astikoor Wheel crafting recipe

### DIFF
--- a/src/scripts/crafttweaker/recipes/mods/astikoor.zs
+++ b/src/scripts/crafttweaker/recipes/mods/astikoor.zs
@@ -23,9 +23,9 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	],
 	<astikoor:wheel:0> : [
 		[
-			[<ore:stickWood>.firstItem, <ore:stickWood>.firstItem, <ore:stickWood>.firstItem],
+			[null, <ore:stickWood>.firstItem, null],
 			[<ore:stickWood>.firstItem, <ore:plankWood>, <ore:stickWood>.firstItem],
-			[<ore:stickWood>.firstItem, <ore:stickWood>.firstItem, <ore:stickWood>.firstItem]
+			[null, <ore:stickWood>.firstItem, null]
 		]
 	],
 	<astikoor:plowcart:0> : [


### PR DESCRIPTION
A change in Steve's Carts Reborn [here](https://github.com/TechReborn/StevesCarts/commit/b9c72e09b26ee432cb7139fe9e8227f504fb853d) means that the recipe previously used to craft the Wheel from Astikoor no longer functions in 3.1.0 as it conflicts with the new crafting recipe for Wooden Wheels from Steve's Carts.

This changes the recipe in SevTech for the Astikoor Wheel so that it now uses the recipe previously used by Steve's Carts - using 4 sticks in a plus pattern and a block of wooden planks in the centre instead of 8 sticks and a block of planks previously.

Prior to making this change, I granted myself all advancements in a test world and confirmed that the updated recipe is not presently used by anything else in SevTech. The recipe gave no result.