### PR TITLE
Fix: crafting recipes with enchanted books

### DIFF
--- a/src/scripts/crafttweaker/integrations/mods/appliedenergistics2.zs
+++ b/src/scripts/crafttweaker/integrations/mods/appliedenergistics2.zs
@@ -71,11 +71,11 @@ function init() {
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:2>, <refinedstorage:upgrade:0>, false, <minecraft:sugar:0>, <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:3>, <refinedstorage:upgrade:0>, false, <ore:workbench>, <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:6>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 33 as short}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 33}]}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:7>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 35 as short}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 35}]}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:8>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 2 as short, id: 35 as short}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 2 as short, id: 35}]}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:9>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 3 as short, id: 35 as short}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 3 as short, id: 35}]}), <minecraft:redstone:0>);
 }

--- a/src/scripts/crafttweaker/integrations/mods/appliedenergistics2.zs
+++ b/src/scripts/crafttweaker/integrations/mods/appliedenergistics2.zs
@@ -71,11 +71,11 @@ function init() {
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:2>, <refinedstorage:upgrade:0>, false, <minecraft:sugar:0>, <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:3>, <refinedstorage:upgrade:0>, false, <ore:workbench>, <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:6>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 33}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:silk_touch>.makeEnchantment(1).makeTag().ench}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:7>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 35}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(1).makeTag().ench}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:8>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 2 as short, id: 35}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(2).makeTag().ench}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:9>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 3 as short, id: 35}]}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(3).makeTag().ench}), <minecraft:redstone:0>);
 }

--- a/src/scripts/crafttweaker/recipes/mods/actuallyadditions.zs
+++ b/src/scripts/crafttweaker/recipes/mods/actuallyadditions.zs
@@ -260,14 +260,14 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	<actuallyadditions:item_drill_upgrade_fortune:0>: [
 		[
 			[<minecraft:glowstone:0>, <minecraft:redstone:0>, <minecraft:glowstone:0>],
-			[<minecraft:redstone:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 35}]}), <minecraft:redstone:0>],
+			[<minecraft:redstone:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(1).makeTag().ench}), <minecraft:redstone:0>],
 			[<minecraft:glowstone:0>, <minecraft:redstone:0>, <minecraft:glowstone:0>]
 		]
 	],
 	<actuallyadditions:item_drill_upgrade_fortune_ii:0>: [
 		[
 			[<minecraft:glowstone:0>, metals.redstoneAlloy.plate, <minecraft:glowstone:0>],
-			[metals.redstoneAlloy.plate, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 3 as short, id: 35}]}), metals.redstoneAlloy.plate],
+			[metals.redstoneAlloy.plate, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(3).makeTag().ench}), metals.redstoneAlloy.plate],
 			[<minecraft:glowstone:0>, metals.redstoneAlloy.plate, <minecraft:glowstone:0>]
 		]
 	],
@@ -323,7 +323,7 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	<actuallyadditions:block_fishing_net:0>: [
 		[
 			[<minecraft:string:0>, <minecraft:string:0>, <minecraft:string:0>],
-			[<minecraft:string:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 61}]}), <minecraft:string:0>],
+			[<minecraft:string:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:luck_of_the_sea>.makeEnchantment(1).makeTag().ench}), <minecraft:string:0>],
 			[<minecraft:string:0>, <minecraft:string:0>, <minecraft:string:0>]
 		]
 	],

--- a/src/scripts/crafttweaker/recipes/mods/actuallyadditions.zs
+++ b/src/scripts/crafttweaker/recipes/mods/actuallyadditions.zs
@@ -260,14 +260,14 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	<actuallyadditions:item_drill_upgrade_fortune:0>: [
 		[
 			[<minecraft:glowstone:0>, <minecraft:redstone:0>, <minecraft:glowstone:0>],
-			[<minecraft:redstone:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 35 as short}]}), <minecraft:redstone:0>],
+			[<minecraft:redstone:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 35}]}), <minecraft:redstone:0>],
 			[<minecraft:glowstone:0>, <minecraft:redstone:0>, <minecraft:glowstone:0>]
 		]
 	],
 	<actuallyadditions:item_drill_upgrade_fortune_ii:0>: [
 		[
 			[<minecraft:glowstone:0>, metals.redstoneAlloy.plate, <minecraft:glowstone:0>],
-			[metals.redstoneAlloy.plate, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 3 as short, id: 35 as short}]}), metals.redstoneAlloy.plate],
+			[metals.redstoneAlloy.plate, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 3 as short, id: 35}]}), metals.redstoneAlloy.plate],
 			[<minecraft:glowstone:0>, metals.redstoneAlloy.plate, <minecraft:glowstone:0>]
 		]
 	],
@@ -323,7 +323,7 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	<actuallyadditions:block_fishing_net:0>: [
 		[
 			[<minecraft:string:0>, <minecraft:string:0>, <minecraft:string:0>],
-			[<minecraft:string:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 61 as short}]}), <minecraft:string:0>],
+			[<minecraft:string:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 61}]}), <minecraft:string:0>],
 			[<minecraft:string:0>, <minecraft:string:0>, <minecraft:string:0>]
 		]
 	],

--- a/src/scripts/crafttweaker/recipes/mods/overloaded.zs
+++ b/src/scripts/crafttweaker/recipes/mods/overloaded.zs
@@ -32,23 +32,23 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	],
 	<overloaded:infinite_barrel:0>: [
 		[
-			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <quantumstorage:quantum_storage_unit:0>],
-			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <industrialforegoing:black_hole_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]})],
-			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <quantumstorage:quantum_storage_unit:0>]
+			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_storage_unit:0>],
+			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <industrialforegoing:black_hole_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]})],
+			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_storage_unit:0>]
 		]
 	],
 	<overloaded:infinite_tank:0>: [
 		[
-			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <quantumstorage:quantum_tank:0>],
-			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <industrialforegoing:black_hole_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]})],
-			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <quantumstorage:quantum_tank:0>]
+			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_tank:0>],
+			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <industrialforegoing:black_hole_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]})],
+			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_tank:0>]
 		]
 	],
 	<overloaded:infinite_capacitor:0>: [
 		[
-			[<extraplanets:ultimate_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <actuallyadditions:item_battery_quintuple:0>],
-			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <integrateddynamics:energy_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]})],
-			[<actuallyadditions:item_battery_quintuple:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51 as short}]}), <extraplanets:ultimate_battery:0>]
+			[<extraplanets:ultimate_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <actuallyadditions:item_battery_quintuple:0>],
+			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <integrateddynamics:energy_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]})],
+			[<actuallyadditions:item_battery_quintuple:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <extraplanets:ultimate_battery:0>]
 		]
 	],
 	<overloaded:hyper_item_receiver:0>: [

--- a/src/scripts/crafttweaker/recipes/mods/overloaded.zs
+++ b/src/scripts/crafttweaker/recipes/mods/overloaded.zs
@@ -32,23 +32,23 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 	],
 	<overloaded:infinite_barrel:0>: [
 		[
-			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_storage_unit:0>],
-			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <industrialforegoing:black_hole_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]})],
-			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_storage_unit:0>]
+			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <quantumstorage:quantum_storage_unit:0>],
+			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <industrialforegoing:black_hole_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench})],
+			[<quantumstorage:quantum_storage_unit:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <quantumstorage:quantum_storage_unit:0>]
 		]
 	],
 	<overloaded:infinite_tank:0>: [
 		[
-			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_tank:0>],
-			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <industrialforegoing:black_hole_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]})],
-			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <quantumstorage:quantum_tank:0>]
+			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <quantumstorage:quantum_tank:0>],
+			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <industrialforegoing:black_hole_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench})],
+			[<quantumstorage:quantum_tank:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <quantumstorage:quantum_tank:0>]
 		]
 	],
 	<overloaded:infinite_capacitor:0>: [
 		[
-			[<extraplanets:ultimate_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <actuallyadditions:item_battery_quintuple:0>],
-			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <integrateddynamics:energy_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]})],
-			[<actuallyadditions:item_battery_quintuple:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 51}]}), <extraplanets:ultimate_battery:0>]
+			[<extraplanets:ultimate_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <actuallyadditions:item_battery_quintuple:0>],
+			[<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <integrateddynamics:energy_battery:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench})],
+			[<actuallyadditions:item_battery_quintuple:0>, <minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:infinity>.makeEnchantment(1).makeTag().ench}), <extraplanets:ultimate_battery:0>]
 		]
 	],
 	<overloaded:hyper_item_receiver:0>: [

--- a/src/scripts/crafttweaker/recipes/mods/stevescarts.zs
+++ b/src/scripts/crafttweaker/recipes/mods/stevescarts.zs
@@ -84,8 +84,8 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[
 				null,
 				<minecraft:enchanted_book:0>
-					.withTag({StoredEnchantments: [{lvl: 5 as short, id: 32 as short}]})
-					.onlyWithTag({StoredEnchantments: [{lvl: 5 as short, id: 32 as short}]}),
+					.withTag({StoredEnchantments: [{lvl: 5 as short, id: 32}]})
+					.onlyWithTag({StoredEnchantments: [{lvl: 5 as short, id: 32}]}),
 				null
 			],
 			[null, <minecraft:redstone:0>, null],
@@ -95,8 +95,8 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[
 				null,
 				<minecraft:enchanted_book:0>
-					.withTag({StoredEnchantments: [{lvl: 4 as short, id: 32 as short}]})
-					.onlyWithTag({StoredEnchantments: [{lvl: 4 as short, id: 32 as short}]}),
+					.withTag({StoredEnchantments: [{lvl: 4 as short, id: 32}]})
+					.onlyWithTag({StoredEnchantments: [{lvl: 4 as short, id: 32}]}),
 				null
 			],
 			[metals.iron.ingot, <immersiveengineering:material:27>, metals.iron.ingot],
@@ -106,8 +106,8 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[
 				<minecraft:redstone:0>,
 				<minecraft:enchanted_book:0>
-					.withTag({StoredEnchantments: [{lvl: 3 as short, id: 32 as short}]})
-					.onlyWithTag({StoredEnchantments: [{lvl: 3 as short, id: 32 as short}]}),
+					.withTag({StoredEnchantments: [{lvl: 3 as short, id: 32}]})
+					.onlyWithTag({StoredEnchantments: [{lvl: 3 as short, id: 32}]}),
 				<minecraft:redstone:0>
 			],
 			[metals.iron.ingot, <stevescarts:modulecomponents:16>, metals.iron.ingot],
@@ -117,8 +117,8 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[
 				<minecraft:redstone:0>,
 				<minecraft:enchanted_book:0>
-					.withTag({StoredEnchantments: [{lvl: 2 as short, id: 32 as short}]})
-					.onlyWithTag({StoredEnchantments: [{lvl: 2 as short, id: 32 as short}]}),
+					.withTag({StoredEnchantments: [{lvl: 2 as short, id: 32}]})
+					.onlyWithTag({StoredEnchantments: [{lvl: 2 as short, id: 32}]}),
 				<minecraft:redstone:0>
 			],
 			[metals.reinforcedMetal.ingot, <stevescarts:modulecomponents:16>, metals.reinforcedMetal.ingot],
@@ -128,8 +128,8 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[
 				<immersiveengineering:material:27>,
 				<minecraft:enchanted_book:0>
-					.withTag({StoredEnchantments: [{lvl: 1 as short, id: 32 as short}]})
-					.onlyWithTag({StoredEnchantments: [{lvl: 1 as short, id: 32 as short}]}),
+					.withTag({StoredEnchantments: [{lvl: 1 as short, id: 32}]})
+					.onlyWithTag({StoredEnchantments: [{lvl: 1 as short, id: 32}]}),
 				<immersiveengineering:material:27>
 			],
 			[metals.reinforcedMetal.ingot, <stevescarts:modulecomponents:16>, metals.reinforcedMetal.ingot],
@@ -141,8 +141,8 @@ static shapedRecipes as IIngredient[][][][IItemStack] = {
 			[
 				metals.galgadorian.ingot,
 				<minecraft:enchanted_book:0>
-					.withTag({StoredEnchantments: [{lvl: 5 as short, id: 32 as short}]})
-					.onlyWithTag({StoredEnchantments: [{lvl: 5 as short, id: 32 as short}]}),
+					.withTag({StoredEnchantments: [{lvl: 5 as short, id: 32}]})
+					.onlyWithTag({StoredEnchantments: [{lvl: 5 as short, id: 32}]}),
 				metals.galgadorian.ingot
 			],
 			[metals.galgadorian.ingot, <stevescarts:modulecomponents:16>, metals.galgadorian.ingot],


### PR DESCRIPTION
Due to addition of JEID, enchantment IDs are no longer shorts, which meant certain items were not craftable.

Particular example - RS Fortune Upgrade inscriber recipe did not recognise enchanted book post update. Removed ID being cast as short wherever it was present to prevent this from coming up elsewhere.