### PR TITLE
fix: inscriber enchanted book recipes

### DIFF
--- a/src/scripts/crafttweaker/integrations/mods/appliedenergistics2.zs
+++ b/src/scripts/crafttweaker/integrations/mods/appliedenergistics2.zs
@@ -70,12 +70,14 @@ function init() {
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:1>, <refinedstorage:upgrade:0>, false, <minecraft:ender_pearl:0>, <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:2>, <refinedstorage:upgrade:0>, false, <minecraft:sugar:0>, <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:3>, <refinedstorage:upgrade:0>, false, <ore:workbench>, <minecraft:redstone:0>);
+
+	// Must explicitly define NBT here as otherwise inscriber will not recognise enchanted book with JEID installed.
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:6>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:silk_touch>.makeEnchantment(1).makeTag().ench}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 33}]}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:7>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(1).makeTag().ench}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: [{lvl: 1 as short, id: 35}]}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:8>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(2).makeTag().ench}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book>.withTag({StoredEnchantments: [{lvl: 2 as short, id: 35}]}), <minecraft:redstone:0>);
 	appliedEnergistics.addInscribe(<refinedstorage:upgrade:9>, <refinedstorage:upgrade:0>, false,
-			<minecraft:enchanted_book:0>.withTag({StoredEnchantments: <enchantment:minecraft:fortune>.makeEnchantment(3).makeTag().ench}), <minecraft:redstone:0>);
+			<minecraft:enchanted_book>.withTag({StoredEnchantments: [{lvl: 3 as short, id: 35}]}), <minecraft:redstone:0>);
 }


### PR DESCRIPTION
All other enchanted book recipes I tried worked in every variant of crafting table I could come up with and the syntax is cleaner.

Applied Energistics does not like using JEI to populate patterns with enchanted books where the recipes use IEnchantment#makeTag() however this is a minor thing and players can do it manually.