### PR TITLE
fix: dyed wool crafting recipes

### DIFF
--- a/src/scripts/crafttweaker/integrations/dye.zs
+++ b/src/scripts/crafttweaker/integrations/dye.zs
@@ -298,9 +298,9 @@ function init() {
 		var dyeOredict as IOreDictEntry = oreDict.get("dye" ~ utils.capitalize(dyeName));
 		recipes.addShaped("dye_wool_" ~ dyeName,
 			<minecraft:wool:0>.definition.makeStack(dye.metadata) * 8, [
-				[<ore:blockWool>, <ore:blockWool>, <ore:blockWool>],
-				[<ore:blockWool>, dyeOredict, <ore:blockWool>],
-				[<ore:blockWool>, <ore:blockWool>, <ore:blockWool>]
+				[<ore:wool>, <ore:wool>, <ore:wool>],
+				[<ore:wool>, dyeOredict, <ore:wool>],
+				[<ore:wool>, <ore:wool>, <ore:wool>]
 			]
 		);
 	}


### PR DESCRIPTION
`blockWool` oredict is empty in 3.1.x, whichever mod was populating it no longer does.

Use `wool` oredict instead. This is the only instance of a crafting recipe attempting to use `blockWool`.

Closes #3642