### PR TITLE
refactor: remove Steve's Carts Easter Event Items

### DIFF
--- a/src/scripts/crafttweaker/staging/itemsAndRecipes/mods/stevescarts.zs
+++ b/src/scripts/crafttweaker/staging/itemsAndRecipes/mods/stevescarts.zs
@@ -204,7 +204,17 @@ static hiddenItems as IIngredient[] = [
 static hiddenRemove as IIngredient[] = [
 	<stevescarts:cartmodule:87>,
 	<stevescarts:cartmodule:92>,
-	<stevescarts:modulecomponents:9>
+	<stevescarts:modulecomponents:9>,
+
+	// Easter event - the config option is just for show
+	<stevescarts:modulecomponents:66>,
+	<stevescarts:modulecomponents:67>,
+	<stevescarts:modulecomponents:68>,
+	<stevescarts:modulecomponents:69>,
+	<stevescarts:modulecomponents:70>,
+	<stevescarts:modulecomponents:71>,
+	<stevescarts:cartmodule:74>.withTag({Data: 1 as byte})
+
 ];
 
 function init() {


### PR DESCRIPTION
What does that config option do if not disable the Easter Event?

They're definitely gone now.