### PR TITLE
fix: make certain packing recipes reversible using unpacking mold

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -25,6 +25,7 @@ Enhancements:
 * Removed primal tech twine (had no use)
 * Re-introduce Infused Crystal Pickaxe
 * Both carts from AstikorCarts will now trigger the "Love and Carriage" advancement, text clarified
+* More Metal Press packaging recipes can be reversed using an unpacking mold (#3694)
 
 Mod Updates:
 * AbyssalCraft (1.9.5.4)

--- a/src/scripts/crafttweaker/integrations/mods/immersive/engineering/metalPress.zs
+++ b/src/scripts/crafttweaker/integrations/mods/immersive/engineering/metalPress.zs
@@ -21,6 +21,7 @@ function init() {
 
 	// Clay Balls -> Clay Block
 	immersiveEngineering.addPress(<minecraft:clay:0> * 1, <minecraft:clay_ball:0>, <immersiveengineering:mold:5>, 4);
+	immersiveEngineering.addPress(<minecraft:clay_ball:0> * 4, <minecraft:clay:0>, <immersiveengineering:mold:7>, 1);
 
 	// Shadowfragment -> Shadowshard
 	immersiveEngineering.addPress(<abyssalcraft:shadowshard:0> * 1, <abyssalcraft:shadowfragment:0>, <immersiveengineering:mold:6>, 9);
@@ -38,13 +39,17 @@ function init() {
 
 	// Diamond Block
 	immersiveEngineering.addPress(<minecraft:diamond_block:0> * 1, <minecraft:diamond:0>, <immersiveengineering:mold:6>, 9);
+	immersiveEngineering.addPress(<minecraft:diamond:0> * 9, <minecraft:diamond_block:0>, <immersiveengineering:mold:7>, 1);
 
 	// Lapis Block
 	immersiveEngineering.addPress(<minecraft:lapis_block:0> * 1, <minecraft:dye:4>, <immersiveengineering:mold:6>, 9);
+	immersiveEngineering.addPress(<minecraft:dye:4> * 9, <minecraft:lapis_block:0>, <immersiveengineering:mold:7>, 1);
 
 	// Redstone Block
 	immersiveEngineering.addPress(<minecraft:redstone_block:0> * 1, <minecraft:redstone:0>, <immersiveengineering:mold:6>, 9);
+	immersiveEngineering.addPress(<minecraft:redstone:0> * 9, <minecraft:redstone_block:0>, <immersiveengineering:mold:7>, 1);
 
 	// Emerald Block
 	immersiveEngineering.addPress(<minecraft:emerald_block:0> * 1, <minecraft:emerald:0>, <immersiveengineering:mold:6>, 9);
+	immersiveEngineering.addPress(<minecraft:emerald:0> * 9, <minecraft:emerald_block:0>, <immersiveengineering:mold:7>, 1);
 }


### PR DESCRIPTION
Adds unpacking recipe for:
* Clay Blocks
* Diamond Blocks
* Lapis Blocks
* Redstone Blocks
* Emerald Blocks

closes #3694