### PR TITLE
fix: add JEID error biome to Nature's Compass blacklist

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -20,6 +20,7 @@ Bug Fixes:
 * Prevent pickup of Transport Cart with carryon (#3640)
 * Restaged Better With Addons pies to two, where they are obtainbale (#3633)
 * Fixed item drops for various blocks that were overridden in scripts (#3673)
+* Removed JEID error biome from Nature's Compass search GUI (#3612)
 
 Enhancements:
 * Removed primal tech twine (had no use)

--- a/src/config/naturescompass.cfg
+++ b/src/config/naturescompass.cfg
@@ -15,6 +15,7 @@ client {
 general {
     # naturescompass.biomeBlacklist
     S:"A list of biomes that the compass will not be able to search for. Both biome names and numerical biome IDs are accepted." <
+        A mod doesn't support extended biome IDs -- report to JEID
         Abyssal Wastelands
         Arctic Abyss
         Autumnal Wooded Hills


### PR DESCRIPTION
closes #3612