### PR TITLE
fix: Light Gray Dye Powder now useable in AE2 Color Applicator

### DIFF
--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -28,6 +28,7 @@ Enhancements:
 * Re-introduce Infused Crystal Pickaxe
 * Both carts from AstikorCarts will now trigger the "Love and Carriage" advancement, text clarified
 * More Metal Press packaging recipes can be reversed using an unpacking mold (#3694)
+* Light gray dye powder now accepted by the AE2 Color Applicator (#3683)
 
 Mod Updates:
 * AbyssalCraft (1.9.5.4)

--- a/src/scripts/crafttweaker/integrations/dye.zs
+++ b/src/scripts/crafttweaker/integrations/dye.zs
@@ -304,4 +304,6 @@ function init() {
 			]
 		);
 	}
+
+	<ore:dyeSilver>.add(<ore:dyeLightGray>.firstItem); // TODO: remove when AE2 accepts dyeLightGray
 }


### PR DESCRIPTION
AE2 looks in the dyeSilver ore dictionary for Light Gray. This does not exist without script creating it. Note this is also a problem in a "vanilla" AE2 setup - dyeSilver does not exist in this case either.

closes #3683