### PR TITLE
fix: Blacklist Chisels and Bits blocks from being picked up by carryon

### DIFF
--- a/src/config/carryon.cfg
+++ b/src/config/carryon.cfg
@@ -141,6 +141,7 @@ general {
             ceramics:clay_barrel:1
             ceramics:clay_barrel_stained_extension:*
             ceramics:porcelain_barrel_extension:*
+            chiselsandbits:*
             colossalchests:*
             compactmachines3:*
             cookingforblockheads:*

--- a/src/config/mputils/changelog.txt
+++ b/src/config/mputils/changelog.txt
@@ -23,6 +23,7 @@ Bug Fixes:
 * Removed JEID error biome from Nature's Compass search GUI (#3612)
 * Correctly stage Aqueduct constructed from stone bricks (#3635)
 * Galacticraft Emergency Kits can now be crafted using their normal recipe (#3692)
+* Blacklist chisels and bits blocks from being picked up using carryon (#3711)
 
 Enhancements:
 * Removed primal tech twine (had no use)


### PR DESCRIPTION
closes #3711 