### PR TITLE
fix: blacklist enderstorage blocks in carryon

### DIFF
--- a/src/config/carryon.cfg
+++ b/src/config/carryon.cfg
@@ -153,6 +153,7 @@ general {
             embers:catalyzer
             embers:combustor
             embers:mixer
+            enderstorage:*
             environmentaltech:*
             extraplanets:advanced_launch_pad:*
             farmingforblockheads:market


### PR DESCRIPTION
closes #3724