### PR TITLE
UltimateCarMod accepted fuel fix

### DIFF
--- a/src/config/car/car.json
+++ b/src/config/car/car.json
@@ -6,7 +6,7 @@
   "speed": 0.5,
   "fluids": [{
    "efficiency": 0.3,
-   "fluid": "bio_diesel"
+   "fluid": "biodiesel"
   }]
  },
  {
@@ -16,7 +16,7 @@
   "speed": 0.48,
   "fluids": [{
    "efficiency": 0.2,
-   "fluid": "bio_diesel"
+   "fluid": "biodiesel"
   }]
  },
  {
@@ -26,7 +26,7 @@
   "speed": 0.4,
   "fluids": [{
    "efficiency": 0.3,
-   "fluid": "bio_diesel"
+   "fluid": "biodiesel"
   }]
  },
  {
@@ -36,7 +36,7 @@
   "speed": 0.65,
   "fluids": [{
    "efficiency": 0.12,
-   "fluid": "bio_diesel"
+   "fluid": "biodiesel"
   }]
  }
 ]}

--- a/src/config/car/fuel_station.json
+++ b/src/config/car/fuel_station.json
@@ -1,1 +1,1 @@
-{"valid_fluids": ["bio_diesel"]}
+{"valid_fluids": ["biodiesel"]}

--- a/src/config/car/generator.json
+++ b/src/config/car/generator.json
@@ -1,4 +1,4 @@
 {"generator_fluids": [{
- "fluid": "bio_diesel",
+ "fluid": "biodiesel",
  "energy": 500
 }]}


### PR DESCRIPTION
The fuel used in the UltimateCarMod is labelled "bio_diesel". However, the bio diesel enabled in the modpack is IE's "biodiesel". On my personal savefile i changed these values and now the mod works as intended.