### PR TITLE
Update carryon.cfg

### DIFF
--- a/src/config/carryon.cfg
+++ b/src/config/carryon.cfg
@@ -263,7 +263,7 @@ general {
             minecraft:wooden_door
             mob_grinding_utils:absorption_hopper
             modularmachinery:*
-            nex:tile_urn_sorrow
+            nex:urn_of_sorrow
             opencomputers:*
             overloaded:*
             placeableitems:*


### PR DESCRIPTION
Urn of sorrow has the id nex:urn_of_sorrow. Without this, items placed in the urn of sorrow cannot be removed by shift + right click and the urn is picked up instead.