### PR TITLE
Make diamond and emerald blocks chisel-able

### DIFF
--- a/src/scripts/crafttweaker/_globals/chiselBlocks.zs
+++ b/src/scripts/crafttweaker/_globals/chiselBlocks.zs
@@ -78,6 +78,7 @@ global chiselBlocks as IItemStack[][IOreDictEntry] = {
 		<chisel:blockcopper:6>
 	],
 	<ore:blockDiamond>: [
+		<minecraft:diamond_block:0>,
 		<chisel:diamond:0>,
 		<chisel:diamond:1>,
 		<chisel:diamond:2>,
@@ -101,6 +102,7 @@ global chiselBlocks as IItemStack[][IOreDictEntry] = {
 		<chisel:blockelectrum:6>
 	],
 	<ore:blockEmerald>: [
+		<minecraft:emerald_block:0>,
 		<chisel:emerald:0>,
 		<chisel:emerald:1>,
 		<chisel:emerald:2>,


### PR DESCRIPTION
This looks like some sort of work around because it doesn't get rid of the empty chisel block groups for diamond and emerald blocks, but it works. I just copied the previously applied fix for lapis blocks, which also has an empty chisel block group.